### PR TITLE
Convert to int

### DIFF
--- a/src/lambda.py
+++ b/src/lambda.py
@@ -59,6 +59,9 @@ def lambda_handler(event, context):
     vpc_id = event["ResourceProperties"]["VpcId"]
     sizes = event["ResourceProperties"]["Sizes"]
 
+    # Convert to int any item containing numbers
+    sizes = map(int, sizes)
+    
     # Check the sizes are valid
     if any(size < 16 or size > 28 for size in sizes):
         return send_response(event, context, "FAILED", reason="An invalid subnet size was specified: {}".format(", ".join(sizes)))


### PR DESCRIPTION
Python may parse parameters as strings, even when not passed as such via CloudFormation:
CloudFormation:
```
Sizes: [ 25, 25, 25, 25, 25, 25, 25, 25 ] 
```

CloudWatch logs:
```
sizes: [u'25', u'25', u'25', u'25', u'25', u'25', u'25', u'25']
```

This patch makes sure that any item containing valid integers are evaluated as such.