### PR TITLE
Refactoring and adding unit tests

### DIFF
--- a/src/lambda.py
+++ b/src/lambda.py
@@ -13,6 +13,7 @@ import json
 from urllib2 import HTTPError, build_opener, HTTPHandler, Request
 
 from cidr_findr import find_next_subnet
+from lambda_utils import parse_size, are_sizes_valid
 
 def send_response(event, context, response_status, reason=None, response_data={}):
     response_body = {
@@ -59,11 +60,10 @@ def lambda_handler(event, context):
     vpc_id = event["ResourceProperties"]["VpcId"]
     sizes = event["ResourceProperties"]["Sizes"]
 
-    # Convert to int any item containing numbers
-    sizes = map(int, sizes)
-    
+    sizes = map(parse_size, sizes)
+
     # Check the sizes are valid
-    if any(size < 16 or size > 28 for size in sizes):
+    if are_sizes_valid(sizes):
         return send_response(event, context, "FAILED", reason="An invalid subnet size was specified: {}".format(", ".join(sizes)))
 
     # Query existing subnets

--- a/src/lambda.py
+++ b/src/lambda.py
@@ -59,6 +59,9 @@ def lambda_handler(event, context):
     vpc_id = event["ResourceProperties"]["VpcId"]
     sizes = event["ResourceProperties"]["Sizes"]
 
+    # Convert to int any item containing numbers
+    sizes = map(int, sizes)
+    
     # Check the sizes are valid
     if any(size < 16 or size > 28 for size in sizes):
         return send_response(event, context, "FAILED", reason="An invalid subnet size was specified: {}".format(", ".join(sizes)))

--- a/src/lambda_utils.py
+++ b/src/lambda_utils.py
@@ -1,0 +1,26 @@
+"""
+Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+
+http://aws.amazon.com/apache2.0/
+
+or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+"""
+
+def parse_size(size):
+    """
+    Parse the size parameter
+    """
+    if isinstance(size, int):
+       return size
+    elif isinstance(size, str):
+       if size.isdigit():
+          return int(size)
+    return None
+
+def are_sizes_valid(sizes):
+    """
+    Validate the subnet masks
+    """
+    return all(isinstance(size, int) and size >= 16 and size <= 28 for size in sizes)

--- a/src/test.py
+++ b/src/test.py
@@ -9,6 +9,7 @@ or in the "license" file accompanying this file. This file is distributed on an 
 """
 
 from cidr_findr import find_next_subnet
+from lambda_utils import parse_size, are_sizes_valid
 import unittest
 
 class CidrFindrTestCase(unittest.TestCase):
@@ -162,6 +163,31 @@ class CidrFindrTestCase(unittest.TestCase):
             requests=[25],
             expected=["10.0.0.0/25"],
         )
+
+    def test_string_integers(self):
+        """
+        Subnet mask passed as string
+        """
+        sizes=["25",24,"23"]
+        sizes = map(parse_size, sizes)
+
+        self.assertTrue(all(isinstance(size, int) for size in sizes))
+
+    def test_subnet_too_small(self):
+        """
+        Subnet masks are too small
+        """
+        sizes = [29]
+
+        self.assertFalse(are_sizes_valid(sizes))
+
+    def test_subnet_too_large(self):
+        """
+        Subnet masks are too big
+        """
+        sizes = [15]
+
+        self.assertFalse(are_sizes_valid(sizes))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
```
map(int, sizes) 
```
and
```
if any(size < 16 or size > 28 for size in sizes):
```

- the first is prone to hard-fail on non-castable items - e.g. ```int("abc")```
- both are non unit-testable

Parameter casting and validation have been refactored to soft fail and to be testable.